### PR TITLE
ギフト券一覧表示、バックエンドでのログイン処理、オリジナルギフト券保存機能

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,7 +28,16 @@ Rails/HasManyOrHasOneDependent:
 
 Metrics/MethodLength:
   CountComments: false
-  Max: 50
+  Max: 100
 
 Layout/ArgumentAlignment:
+  Enabled: false
+
+Style/HashSyntax:
+  Enabled: false
+
+Layout/LineLength:
+  Enabled: false
+
+Metrics/AbcSize:
   Enabled: false

--- a/app/controllers/gifts_controller.rb
+++ b/app/controllers/gifts_controller.rb
@@ -1,0 +1,10 @@
+class GiftsController < ApplicationController
+  def index
+    @gifts = Gift.all
+    @template_gifts = GiftCardTemplate.where(has_message: true)
+  end
+
+  def show
+    @gift = Gift.find(params[:id])
+  end
+end

--- a/app/controllers/original_gifts_controller.rb
+++ b/app/controllers/original_gifts_controller.rb
@@ -5,44 +5,70 @@ class OriginalGiftsController < ApplicationController
     render 'gift_creator'
   end
 
-  # プレビュー機能
-  def preview
-    gift = Gift.new(gift_params)
-    design = GiftCardTemplate.find(gift.design_id)
+  def create
+    @gift = Gift.new(gift_params)
+    Rails.logger.debug { "Gift params: #{gift_params.inspect}" }
+    Rails.logger.debug { "Gift design_id: #{@gift.design_id}" }
+    design = GiftCardTemplate.find(@gift.design_id)
 
-    image_url = Cloudinary::Uploader.upload(design.image_url,
-      transformation: [
-        {
-          overlay: "text:Arial_20:TO: #{gift.recipient}",
-          gravity: "north_west",
-          x: 100, y: 100,
-          color: "#000000"
-        },
-        {
-          overlay: "text:Arial_40:#{gift.title}",
-          gravity: "center",
-          color: "#000000"
-        },
-        {
-          overlay: "text:Arial_20:#{gift.content}",
-          gravity: "center",
-          y: 50, # Y軸を調整してテキストを中央より下に配置
-          color: "#000000"
-        },
-        {
-          overlay: "text:Arial_20:有効期限:#{gift.expiration_date}",
-          gravity: "south_east",
-          x: 100, y: 80,
-          color: "#000000"
-        }
-      ])
+    @gift.user = current_user
+    @gift.gift_category = GiftCategory.find_by(category_type: :original)
+    @gift.recipient_category = RecipientCategory.find(gift_params[:recipient_category_id])
 
-    # Turbo Streamを使用してプレビュー画像を更新
-    respond_to do |format|
-      format.turbo_stream do
-        render turbo_stream: turbo_stream.update('preview_area',
-                                                  partial: 'original_gifts/preview',
-                                                  locals: { preview_url: image_url['url'] })
+    # original カテゴリーの GiftCategory を取得
+    original_category = GiftCategory.find_by(category_type: :original)
+    # GiftCategory を Gift オブジェクトに関連付ける
+    @gift.gift_category = original_category
+
+    case params[:commit]
+    when 'preview'
+      # 同じくCloudinaryを使用して画像を合成
+      image_url = Cloudinary::Uploader.upload(design.image_url,
+        transformation: [
+          {
+            overlay: "text:Arial_40:#{@gift.title}",
+            gravity: "center",
+            color: "#000000"
+          },
+          {
+            overlay: "text:Arial_20:#{@gift.content}",
+            gravity: "center",
+            y: 50, # Y軸を調整してテキストを中央より下に配置
+            color: "#000000"
+          }
+        ])
+
+      respond_to do |format|
+        format.turbo_stream do
+          render turbo_stream: turbo_stream.update('preview_area',
+                                                    partial: 'original_gifts/preview',
+                                                    locals: { preview_url: image_url['url'] })
+        end
+      end
+
+    when 'create'
+      # 作成処理
+      image_url = Cloudinary::Uploader.upload(design.image_url,
+        transformation: [
+          {
+            overlay: "text:Arial_40:#{@gift.title}",
+            gravity: "center",
+            color: "#000000"
+          },
+          {
+            overlay: "text:Arial_20:#{@gift.content}",
+            gravity: "center",
+            y: 50, # Y軸を調整してテキストを中央より下に配置
+            color: "#000000"
+          }
+        ])
+      @gift.image_url = image_url['url']
+      if @gift.save
+        redirect_to gift_path(@gift)
+      else
+        Rails.logger.debug { @gift.errors.full_messages }
+        @templates = GiftCardTemplate.where(has_message: false)
+        render 'gift_creator'
       end
     end
   end
@@ -50,6 +76,10 @@ class OriginalGiftsController < ApplicationController
   private
 
   def gift_params
-    params.require(:gift).permit(:recipient, :expiration_date, :design_id, :title, :content)
+    params.require(:gift).permit(:recipient, :expiration_date, :design_id, :title, :content, :public_status, :recipient_category_id)
+  end
+
+  def current_user
+    @current_user ||= User.find_by(id: session[:user_id])
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,44 @@
+class UsersController < ApplicationController
+  def show
+    @user = User.find_by(id: session[:user_id])
+  end
+
+  def create
+    # LIFFから取得したIDトークン
+    id_token = params[:idToken]
+    # LINEプラットフォームで設定されたチャネルID
+    channel_id = ENV.fetch('LINE_CHANNEL_ID')
+
+    Rails.logger.info { "ID Token: #{id_token}" }
+    Rails.logger.info { "Channel ID: #{channel_id}" }
+
+    # IDトークンをLINEプラットフォームに送信してユーザー情報を取得
+    res = Net::HTTP.post_form(URI.parse('https://api.line.me/oauth2/v2.1/verify'), { 'id_token' => id_token, 'client_id' => channel_id })
+    Rails.logger.info { "Response Status: #{res.code}" } # ステータスコード
+    Rails.logger.info { "Response Body: #{res.body}" } # レスポンス本文
+
+    begin
+      profile = JSON.parse(res.body)
+      Rails.logger.info { "Parsed JSON: #{profile}" }
+    rescue JSON::ParserError => e
+      Rails.logger.error { "JSON Parsing Error: #{e.message}" }
+    end
+    line_user_id = profile['sub']
+
+    Rails.logger.info { "LINE User ID: #{line_user_id}" }
+
+    user = User.find_or_create_by(line_user_id: line_user_id) do |u|
+      u.name = profile['name'] # LINEのユーザー名
+      u.avatar = profile['picture'] # LINEのプロフィール画像URL
+    end
+
+    Rails.logger.info { "User created or found: #{user.inspect}" }
+
+    # セッションにユーザーIDを保存
+    session[:user_id] = user.id
+    Rails.logger.info { "Session user_id: #{session[:user_id]}" }
+
+    # 必要に応じてリダイレクトやJSONレスポンスを返す
+    render json: user
+  end
+end

--- a/app/views/gifts/index.html.erb
+++ b/app/views/gifts/index.html.erb
@@ -1,0 +1,17 @@
+<h1>ギフト券一覧</h1>
+
+<h2>テンプレートギフト券</h2>
+<% @template_gifts.each do |template_gift| %>
+  <div>
+    <p><%= image_tag template_gift.image_url %></p>
+    <!-- その他のテンプレートギフト券情報を表示 -->
+  </div>
+<% end %>
+
+<h2>その他のギフト券</h2>
+<% @gifts.each do |gift| %>
+  <div>
+    <p><%= image_tag gift.image_url %></p>
+    <!-- その他のギフト券情報を表示 -->
+  </div>
+<% end %>

--- a/app/views/gifts/show.html.erb
+++ b/app/views/gifts/show.html.erb
@@ -1,0 +1,11 @@
+<div class="flex flex-col items-center">
+  <div class="mb-4">
+    <img src="<%= @gift.image_url %>" alt="<%= @gift.title %>">
+  </div>
+  <div class="mb-4">
+    <p>TO: <%= @gift.recipient %></p>
+    <p>有効期限: <%= @gift.expiration_date %></p>
+  </div>
+
+  <button id="send_gift_button" class="bg-orange-300 text-white rounded px-2 py-2">友だちに贈る</button>
+</div>

--- a/app/views/original_gifts/gift_creator.html.erb
+++ b/app/views/original_gifts/gift_creator.html.erb
@@ -1,5 +1,5 @@
 <div class="flex flex-col items-center">
-  <%= form_with id: 'gift_card_form', model: Gift.new, url: preview_original_gifts_path, local: true do |form| %>
+  <%= form_with id: 'gift_card_form', model: Gift.new, url: original_gifts_path, local: true do |form| %>
     <% @templates.each do |template| %>
       <label>
         <%= form.radio_button :design_id, template.id %>
@@ -7,12 +7,44 @@
       </label>
     <% end %>
 
-    <%= form.text_field :recipient, placeholder: '受取人名' %>
-    <%= form.text_field :title, placeholder: 'クーポン名' %>
-    <%= form.text_area :content, placeholder: '一言メッセージ', rows: 3 %>
-    <%= form.date_field :expiration_date %>
-    <div class="text-center">
-      <%= form.submit 'プレビュー', class: "bg-blue-300 text-white rounded px-2 py-2" %>
+    <div class="mb-4">
+      <%= form.label :recipient, '受取人名：' %>
+      <%= form.text_field :recipient, class: "border border-gray-300 rounded px-2 py-1" %>
+    </div>
+
+    <div class="mb-4">
+      <%= form.label :title, 'クーポン名：' %>
+      <%= form.text_field :title, placeholder: '肩たたき券', class: "border border-gray-300 rounded px-2 py-1" %>
+    </div>
+
+    <div class="mb-4">
+      <%= form.label :content, 'メッセージ：' %>
+      <%= form.text_field :content, placeholder: '20文字以下', class: "border border-gray-300 rounded px-2 py-1" %>
+    </div>
+
+    <div class="mb-4">
+      <%= form.label :expiration_date, '有効期限：' %>
+      <%= form.date_field :expiration_date, class: "border border-gray-300 rounded px-2 py-1" %>
+    </div>
+
+    <div class="mb-4">
+      <%= form.label :public_status, '一覧への公開/非公開：' %>
+      <%= form.select :public_status, [['公開', true], ['非公開', false]], include_blank: '選択してください' %>
+    </div>
+
+    <div class="mb-4">
+      <%= form.label :recipient_category_id, '受取人カテゴリ：' %>
+      <%= form.select :recipient_category_id,
+          RecipientCategory.all.map { |category| [I18n.t("enums.recipient_category.category_type.#{category.category_type}"), category.id] },
+          include_blank: '選択してください',
+          class: "border border-gray-300 rounded px-2 py-1" %>
+    </div>
+
+    <div class="text-center mb-4">
+      <%= form.submit 'プレビュー', name: 'commit', value: 'preview', class: "bg-blue-300 text-white rounded px-2 py-2" %>
+    </div>
+    <div class="text-center mb-4">
+      <%= form.submit 'この内容で作成', name: 'commit', value: 'create', class: "bg-purple-300 text-white rounded px-2 py-2" %>
     </div>
   <% end %>
 

--- a/app/views/static_pages/index.html.erb
+++ b/app/views/static_pages/index.html.erb
@@ -10,6 +10,11 @@
   <%= link_to "クーポン券を贈る", static_pages_select_gift_type_path, class: "bg-green-300 text-white rounded px-2 py-2" %>
   <%= link_to "テンプレートクーポン券", template_gifts_path, class: "bg-blue-300 text-white rounded px-2 py-2" %>
   <%= link_to "オリジナルクーポン券", original_gifts_path, class: "bg-red-300 text-white rounded px-2 py-2" %>
+  <% if session[:user_id] %>
+    <%= link_to "プロフィールページ", user_path(session[:user_id]), class: "bg-orange-300 text-white rounded px-2 py-2" %>
+  <% else %>
+    セッションなし
+  <% end %>
   <div id="loggedInMessage" style="display:none;" class="alert">
     ログインしています。
   </div>

--- a/app/views/static_pages/select_gift_type.html.erb
+++ b/app/views/static_pages/select_gift_type.html.erb
@@ -2,7 +2,7 @@
   <p>クーポン券の種類を選択してください</p>
   <%= link_to "テンプレートから選ぶ", template_gifts_path, class: "bg-blue-300 text-white font-bold py-2 px-4 rounded" %>
   <%= link_to "オリジナルクーポン券を作成", original_gifts_path, class: "bg-blue-300 text-white font-bold py-2 px-4 rounded" %>
-  <%= link_to "みんなのクーポン券から選ぶ", root_path, class: "bg-blue-300 text-white font-bold py-2 px-4 rounded" %>
+  <%= link_to "クーポン券一覧から選ぶ", gifts_path, class: "bg-blue-300 text-white font-bold py-2 px-4 rounded" %>
   <div class="flex flex-col items-center">
     <button id="aiButton" class="bg-blue-300 text-white font-bold py-2 px-4 rounded">AIでオリジナルクーポン券を生成</button>
   </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,8 @@
+<h1>ユーザープロフィール</h1>
+
+<p>名前: <%= @user.name %></p>
+<% if @user.avatar.present? %>
+  <p><%= image_tag @user.avatar %></p>
+<% else %>
+  <p>画像はありません。</p>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,8 @@ module App
   class Application < Rails::Application
     config.load_defaults 7.0
 
+    config.i18n.default_locale = :ja
+
     config.generators do |g|
       g.helper false
       g.test_framework false

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,7 +1,8 @@
 ja:
   enums:
     recipient_category:
-      family: "家族"
-      friend: "友人"
-      colleague: "同僚"
-      other: "その他"
+      category_type:
+        family: "家族"
+        friend: "友人"
+        colleague: "同僚"
+        other: "その他"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,7 @@
+ja:
+  enums:
+    recipient_category:
+      family: "家族"
+      friend: "友人"
+      colleague: "同僚"
+      other: "その他"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,13 +3,16 @@ Rails.application.routes.draw do
   get 'static_pages/completion'
   get 'static_pages/select_gift_type'
 
+  resources :users, only: %i[show create]
+  resources :gifts, only: %i[index show]
+
   resources :template_gifts, only: %i[index] do
     collection do
       post :preview
     end
   end
 
-  resources :original_gifts, only: %i[index] do
+  resources :original_gifts, only: %i[index create] do
     collection do
       post :preview
     end

--- a/db/migrate/20240213074909_add_image_url_to_gifts.rb
+++ b/db/migrate/20240213074909_add_image_url_to_gifts.rb
@@ -1,0 +1,5 @@
+class AddImageUrlToGifts < ActiveRecord::Migration[7.0]
+  def change
+    add_column :gifts, :image_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_12_065710) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_13_074909) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -52,6 +52,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_12_065710) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "title"
+    t.string "image_url"
     t.index ["gift_category_id"], name: "index_gifts_on_gift_category_id"
     t.index ["recipient_category_id"], name: "index_gifts_on_recipient_category_id"
     t.index ["user_id"], name: "index_gifts_on_user_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,6 +1,19 @@
-GiftCardTemplate.create([
+GiftCardTemplate.create!([
   { name: '肩たたき券', image_url: 'https://res.cloudinary.com/dk4bsjak1/image/upload/f_auto/v1707704247/%E8%82%A9%E3%81%9F%E3%81%9F%E3%81%8D%E5%88%B8_p8cqbr.png', has_message: true },
   { name: 'カフェ券', image_url: 'https://res.cloudinary.com/dk4bsjak1/image/upload/f_auto/v1707706100/cafe_h3bdsw.png', has_message: true },
   { name: 'star', image_url: 'https://res.cloudinary.com/dk4bsjak1/image/upload/f_auto/v1707708594/star_xjbuvg.png', has_message: false },
   { name: 'blue', image_url: 'https://res.cloudinary.com/dk4bsjak1/image/upload/f_auto/v1707709020/blue_x0nwho.png', has_message: false },
+])
+
+RecipientCategory.create!([
+  { category_type: 'family' },
+  { category_type: 'friend' },
+  { category_type: 'colleague' },
+  { category_type: 'other' }
+])
+
+GiftCategory.create!([
+  { category_type: 'template' },
+  { category_type: 'original' },
+  { category_type: 'ai_generated' },
 ])


### PR DESCRIPTION
## ギフト券一覧表示
- [x] コントローラ、ビュー、ルーティング

## オリジナルギフト券をGiftテーブルに保存できるよう修正
- [x] Giftテーブルにimage_urlカラムを追加（合成した画像のURLを保存するため）
- [x] バリデーションエラーを解消
  - [x] User
   - [x] Gift category→seedファイルでデータを追加
  - [x] Recipient category→seedファイルでデータを追加
- [x] 一つのフォームでpreviewアクションとcreateアクションどちらも対応できるよう修正
## バックエンドでのログイン処理
- [x] Usersコントローラ、ルーティング
- [x] liff.getIDTokenでユーザー情報を取得
[liff.getIDToken()](https://developers.line.biz/ja/reference/liff/#get-id-token)で取得したIDトークンをサーバーに送信した場合は、サーバーでIDトークンを検証する（[POST /oauth2/v2.1/verify](https://developers.line.biz/ja/reference/line-login/#verify-id-token)）ことで、ユーザーのプロフィール情報を安全に取得できる
- [x] 簡易プロフィールページでユーザー名と画像を取得
- [x] チャネルIDを.envで管理
- [x] heroku環境変数にチャネルIDを設定